### PR TITLE
vercelへの自動デプロイでコケたので、nodeのバージョンを１６から１８に変更

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: setup nodejs
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
 
       - name: yarn install
         run: yarn install


### PR DESCRIPTION
vercelへの自動デプロイでコケたので、nodeのバージョンを１６から１８に変更